### PR TITLE
Removed order state and restructured class accordingly.

### DIFF
--- a/Polynomial.py
+++ b/Polynomial.py
@@ -2,6 +2,7 @@
     A simple polynomial class. Supports differentiation, indefinite integration, and console output with class methods.
     Author: Alexander S. Wheaton
     Date: 16 January 2018
+    Updated: 29 January 2018
 """
 
 import math
@@ -11,11 +12,10 @@ class Polynomial(object):
     # Initialises two class variables: the coefficients of the polynomial as a list the its order as an integer.
     def __init__(self, coefficients):
         self.coefficients = coefficients
-        self.order = len(coefficients) - 1
 
     # Returns the order of the polynomial as an integer.
-    def returnOrder(self):
-        return self.order
+    def getOrder(self):
+        return len(self.coefficients) - 1
 
     # Recieves a second Polynomial object and returns the sum of the two polynomials as a third Polynomial object.
     def addPolynomial(self, polynomial):
@@ -23,22 +23,22 @@ class Polynomial(object):
         summedCoefficients = []
 
         # Second Polynomial object has fewer terms than the first.
-        if polynomial.order < self.order:
-            for n in range(0, polynomial.order):
+        if len(polynomial.coefficients) < len(self.coefficients):
+            for n in range(0, len(polynomial.coefficients)):
                 summedCoefficients.append(self.coefficients[n] + polynomial.coefficients[n])
-            for n in range(polynomial.order + 1, self.order):
+            for n in range(len(polynomial.coefficients), len(self.coefficients)):
                 summedCoefficients.append(self.coefficients[n])
 
         # Second Polynomial object has the same number of terms as the first.
-        if polynomial.order == self.order:
-            for n in range(0, self.order):
+        if len(polynomial.coefficients) == len(self.coefficients):
+            for n in range(0, len(self.coefficients)):
                 summedCoefficients.append(self.coefficients[n] + polynomial.coefficients[n])
 
         # Second Polynomial object has more terms than the first.
-        if polynomial.order > self.order:
-            for n in range(0, self.order):
+        if len(polynomial.coefficients) > len(self.coefficients):
+            for n in range(0, len(self.coefficients)):
                 summedCoefficients.append(self.coefficients[n] + polynomial.coefficients[n])
-            for n in range(self.order + 1, polynomial.order):
+            for n in range(len(self.coefficients), len(polynomial.coefficients)):
                 summedCoefficients.append(polynomial.coefficients[n])
 
         # Initialises and returns the sum of the two polynomials as a third Polynomial object.
@@ -47,20 +47,20 @@ class Polynomial(object):
     # Returns a list of the coeffiecients of the derivative of the polynomial.
     def derivative(self):
         differentiatedCoefficients = []
-        for n in range(0, self.order):
-                differentiatedCoefficients.append((n+1) * self.coefficients[n+1])
+        for n in range(1, len(self.coefficients)):
+                differentiatedCoefficients.append(n * self.coefficients[n])
         return Polynomial(differentiatedCoefficients)
 
     # Returns a list of the coefficients of the indefinite integral of the polynomial.
     def integral(self):
         integratedCoefficients = ["C"]
-        for n in range(0, self.order):
+        for n in range(0, len(self.coefficients)):
             integratedCoefficients.append(self.coefficients[n] / (n+1))
         return Polynomial(integratedCoefficients)
 
     # Returns the polynomial as a formatted string.
     def show(self):
         polynomialAsString = "P(x) = " + str(self.coefficients[0])
-        for n in range(0, self.order):
+        for n in range(0, len(self.coefficients)):
             polynomialAsString = polynomialAsString + " + " + str(self.coefficients[n+1]) + "x^" + str(n+1)
         return polynomialAsString


### PR DESCRIPTION
Removed the initialisation of the "order" state from the init method. Class methods can no longer iterate up to "self.order" or "polynomial.order". Instead, the "for" loops in class methods now iterate over the proper values up to the length of the "coefficients" state. Fixes coefficient dropping when using the addPolynomial(), derivative(), and integral() methods.